### PR TITLE
sitemap: configurable decorators for endpoints

### DIFF
--- a/flask_sitemap/config.py
+++ b/flask_sitemap/config.py
@@ -41,16 +41,23 @@ SITEMAP_IGNORE_ENDPOINTS
 ------------------------
 
 Default: ``None``.
+
+SITEMAP_VIEW_DECORAROS
+----------------------
+
+Default: ``[]``.
 """
 
 SITEMAP_BLUEPRINT = 'flask_sitemap'
 
 SITEMAP_BLUEPRINT_URL_PREFIX = '/'
 
-SITEMAP_ENDPOINT_URL = '/sitemap.xml'
+SITEMAP_ENDPOINT_URL = 'sitemap.xml'
 
 SITEMAP_URL_SCHEME = 'http'
 
 SITEMAP_INCLUDE_RULES_WITHOUT_PARAMS = False
 
 SITEMAP_IGNORE_ENDPOINTS = None
+
+SITEMAP_VIEW_DECORATORS = []

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -22,3 +22,7 @@ class FlaskTestCase(TestCase):
         app.config['TESTING'] = True
         app.logger.disabled = True
         self.app = app
+
+
+def dummy_decorator(dummy):
+    return lambda *args, **kwargs: 'dummy'


### PR DESCRIPTION
- Adds an option SITEMAP_VIEW_DECORATORS for specifying list of view
  decorators.  (closes #4)

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
