### PR TITLE
cli: add static sitemap generation 

### DIFF
--- a/flask_sitemap/__init__.py
+++ b/flask_sitemap/__init__.py
@@ -28,11 +28,13 @@ from __future__ import absolute_import
 
 import gzip
 import sys
+import os
 
 from collections import Mapping
 from flask import current_app, request, Blueprint, render_template, url_for, \
     Response, make_response
 from flask.signals import Namespace
+from flask.ext.script import Manager
 from functools import wraps
 from itertools import islice
 from werkzeug.utils import import_string
@@ -252,6 +254,22 @@ class Sitemap(object):
         response.headers["Content-Type"] = "application/xml"
 
         return response
+
+SitemapCommand = Manager(usage="Generate static sitemap")
+
+
+@SitemapCommand.command
+def generate():
+    sitemap = current_app.extensions['sitemap']
+    basedir = os.path.abspath(current_app.config.get('SITEMAP_DIRECTORY'))
+    if not os.path.exists(basedir):
+        os.makedirs(basedir)
+
+    content = sitemap.sitemap()
+    output_file = open(
+        os.path.join(basedir, current_app.config.get("SITEMAP_NAME")), 'w')
+    output_file.write(content)
+    output_file.close()
 
 
 __all__ = ('Sitemap', '__version__', 'sitemap_page_needed')

--- a/flask_sitemap/config.py
+++ b/flask_sitemap/config.py
@@ -72,6 +72,14 @@ there is 10MB limitation for the file.
 
 Default: ``10000``.
 
+SITEMAP_DIRECTORY
+-----------------
+
+The static directory name where sitemap xml files will be created. The
+directory path is relative to flask script directory
+
+Default: ``sitemap``.
+
 """
 
 SITEMAP_BLUEPRINT = 'flask_sitemap'
@@ -93,3 +101,7 @@ SITEMAP_IGNORE_ENDPOINTS = None
 SITEMAP_VIEW_DECORATORS = []
 
 SITEMAP_MAX_URL_COUNT = 10000
+
+SITEMAP_DIRECTORY = 'sitemap'
+
+SITEMAP_NAME = 'sitemap.xml'

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
     install_requires=[
         'Flask',
         'blinker',
+        'Flask-Script',
     ],
     extras_require={
         'docs': ['sphinx'],


### PR DESCRIPTION
I have created a basic version for creating static files. It works well for single xml files, but if you are creating multiple xml files because of url count it does not work. It can be used like 

`manage.py`

```python
from flask.ext.script import Manager
from flask_sitemap import Sitemap, SitemapCommand
from app import app

manager = Manager(app)
sitemap = Sitemap(app)


@manager.command
def hello():
    print "hello"

manager.add_command('sitemap', SitemapCommand)

if __name__ == "__main__":
    manager.run()
```

```python manage.py sitemap generate```

Any ideas on how we can address the multiple file generation?