### PR TITLE
cli: new command line interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ parts/
 sdist/
 var/
 *.egg-info/
+.eggs/
 .installed.cfg
 *.egg
 

--- a/flask_sitemap/__init__.py
+++ b/flask_sitemap/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-Sitemap
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Flask-Sitemap is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -47,12 +47,16 @@ if sys.version_info[0] == 3:  # pragma: no cover
     BytesIO = io.BytesIO
     string_types = str,
     from itertools import zip_longest
-    b = lambda s: s.encode("latin-1")
+
+    def b(s):
+        return s.encode("latin-1")
 else:
     from cStringIO import StringIO as BytesIO
     string_types = basestring,
     from itertools import izip_longest as zip_longest
-    b = lambda s: s
+
+    def b(s):
+        return s
 
 
 # Signals

--- a/flask_sitemap/config.py
+++ b/flask_sitemap/config.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-Sitemap
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Flask-Sitemap is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
 """The details of the application settings that can be customized.
-
 
 SITEMAP_URL_METHOD
 ------------------
@@ -71,7 +70,6 @@ The maximum number of urls per one sitemap file can be up to 50000, however
 there is 10MB limitation for the file.
 
 Default: ``10000``.
-
 """
 
 SITEMAP_BLUEPRINT = 'flask_sitemap'

--- a/flask_sitemap/script.py
+++ b/flask_sitemap/script.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Flask-Sitemap
+# Copyright (C) 2015 CERN.
+#
+# Flask-Sitemap is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Simple command line interface for sitemap generation."""
+
+import os
+import codecs
+import warnings
+
+from flask import current_app, url_for
+
+try:
+    from flask_script import Command, Option
+except ImportError:  # pragma: no cover
+    warnings.warn("Flask-Script package is not installed. "
+                  "Please run `pip install flask_sitemap[cli]`.")
+    raise
+
+from flask_sitemap import sitemap_page_needed
+
+
+class Sitemap(Command):
+
+    """Generate static sitemap."""
+
+    option_list = (
+        Option('--output-directory', '-o', dest='directory', default='.'),
+    )
+
+    def run(self, directory):
+        """Generate static sitemap to given directory."""
+        sitemap = current_app.extensions['sitemap']
+
+        @sitemap_page_needed.connect
+        def generate_page(app, page=1, urlset=None):
+            filename = url_for('flask_sitemap.page', page=page).split('/')[-1]
+            with codecs.open(os.path.join(directory, filename), 'w',
+                             'utf-8') as f:
+                f.write(sitemap.render_page(urlset=urlset))
+
+        filename = url_for('flask_sitemap.sitemap').split('/')[-1]
+        with codecs.open(os.path.join(directory, filename), 'w', 'utf-8') as f:
+            f.write(sitemap.sitemap())

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-Sitemap
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Flask-Sitemap is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -47,13 +47,24 @@ with open(os.path.join('flask_sitemap', 'version.py'), 'rt') as f:
         f.read()
     ).group('version')
 
+extras_require = {
+    'docs': ['sphinx'],
+    'cli': ['Flask-Script'],
+}
+
 tests_require = [
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.6.1',
-    'coverage'
+    'coverage',
 ]
+
+# Extend dependencies with extra packages
+for key, extra in extras_require.items():
+    if key != 'docs':
+        tests_require += extra
+        extras_require['docs'] += extra
 
 setup(
     name='Flask-Sitemap',
@@ -72,9 +83,7 @@ setup(
         'Flask',
         'blinker',
     ],
-    extras_require={
-        'docs': ['sphinx'],
-    },
+    extras_require=extras_require,
     tests_require=tests_require,
     cmdclass={'test': PyTest},
     classifiers=[


### PR DESCRIPTION
* NEW Adds new command line interface to generate sitemap.
  (closes #13)

* NOTE If you want to use command line interface install dependencies
  using `pip install flask-sitemap[cli]`.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>