### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,10 +1,10 @@
 Authors
 =======
 
-Flask-Sitemap is developed for use in `Invenio <http://invenio-software.org>`_
+Flask-Sitemap is developed for use in `Invenio <http://inveniosoftware.org>`_
 digital library software.
 
-Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
+Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 Contributors
 ------------

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -51,8 +51,8 @@ Homepage
 Good luck and thanks for choosing Flask-Sitemap.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: http://github.com/inveniosoftware
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     url='http://github.com/inveniosoftware/flask-sitemap/',
     license='BSD',
     author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description='Flask extension that helps with sitemap generation.',
     long_description=open('README.rst').read(),
     packages=['flask_sitemap'],


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>