### PR TITLE
Fix documentation about SITEMAP_URL_SCHEME

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Contributors
 
 * Jiri Kuncar <jiri.kuncar@cern.ch>
 * Chris Hawkes <noobniche@gmail.com>
+* Albert Wang <aywang31@gmail.com>

--- a/flask_sitemap/config.py
+++ b/flask_sitemap/config.py
@@ -58,8 +58,8 @@ SITEMAP_IGNORE_ENDPOINTS
 
 Default: ``None``.
 
-SITEMAP_VIEW_DECORAROS
-----------------------
+SITEMAP_VIEW_DECORATORS
+-----------------------
 
 Default: ``[]``.
 

--- a/flask_sitemap/config.py
+++ b/flask_sitemap/config.py
@@ -9,7 +9,7 @@
 
 """The details of the application settings that can be customized.
 
-SITEMAP_URL_METHOD
+SITEMAP_URL_SCHEME
 ------------------
 
 Default: ``http``.


### PR DESCRIPTION
The code uses `SITEMAP_URL_SCHEME` but the docs say `SITEMAP_URL_METHOD`