### PR TITLE
Update python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,10 @@ language: python
 sudo: false
 
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 install:
   - pip install --upgrade pip setuptools py


### PR DESCRIPTION
Python 2.6 and 3.3 are end-of-life.  Python 3.6 was released December 2016.