### PR TITLE
Fix pydocstyle test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,10 @@ language: python
 sudo: false
 
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 install:
   - pip install --upgrade pip setuptools py

--- a/flask_sitemap/__init__.py
+++ b/flask_sitemap/__init__.py
@@ -253,7 +253,7 @@ class Sitemap(object):
         return response
 
     def xml_response(self, data):
-        """Standard XML response."""
+        """Return a standard XML response."""
         response = make_response(data)
         response.headers["Content-Type"] = "application/xml"
 


### PR DESCRIPTION
Current tests are failing with

```
$ pydocstyle flask_sitemap
flask_sitemap/__init__.py:255 in public method `xml_response`:
        D401: First line should be in imperative mood; try rephrasing (found 'Standard')
```

The rephrasing of the comment should hopefully pass the linter.