### PR TITLE
Update imports to support python 3.10

### DIFF
--- a/flask_sitemap/__init__.py
+++ b/flask_sitemap/__init__.py
@@ -28,7 +28,12 @@ from __future__ import absolute_import
 
 import gzip
 import sys
-from collections import Mapping
+try:
+    # Python 3.3+
+    from collections.abc import Mapping
+except ImportError:
+    # Python 2
+    from collections import Mapping
 from functools import wraps
 from itertools import islice
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,10 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Development Status :: 5 - Production/Stable'
     ],
 )


### PR DESCRIPTION
`from collections import Mapping` has been deprecated since python 3.3:

```
Python 3.8.10 (default, Sep 28 2021, 16:10:42)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from collections import Mapping
<stdin>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```

This fixes imports to make sure flask-sitemap still works on python 3.10+.  Fixes #50 .