### PR TITLE
Make a new release (v0.3.1) of flask-sitemap

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,15 @@ Changelog
 Here you can see the full list of changes between each Flask-Sitemap
 release.
 
+Version 0.3.1 (released 2022-02-04)
+-----------------------------------
+
+Notes
+~~~~~
+
+- Adds support for python 3.10
+- Moves flask-sitemap from Travis CI to Github Actions
+
 Version 0.3.0 (released 2018-05-02)
 -----------------------------------
 

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,47 +1,29 @@
 ======================
- Flask-Sitemap v0.3.0
+ Flask-Sitemap v0.3.1
 ======================
 
-Flask-Sitemap v0.3.0 was released on May 2, 2018.
+Flask-Sitemap v0.3.1 was released on February 4, 2022.
 
 About
 -----
 
 Flask-Sitemap is a Flask extension helping with sitemap generation.
 
-New features
-------------
-
-- Adds integration with Click library for Flask 0.11+.
-
-Improved features
------------------
-
-- Improves exclusion of specific URLs without parameters
-  from to the sitemap.  (closes #24) (closes #25) (closes #26)
-
-Bug fixes
----------
-
-- Reuses exiting request context if it exits. (closes #35)
-- Prepends '/' to endpoint urls for compatibility with Flask 1.0.
-- Improves documentation about ``SITEMAP_URL_SCHEME``.
-- Fixes typo in ``SITEMAP_VIEW_DECORATORS``.
-
 Notes
 -----
 
-- Removes support for Python 2.6 and 3.3.
+- Adds support for python 3.10
+- Moves flask-sitemap from Travis CI to Github Actions
 
 Installation
 ------------
 
-   $ pip install Flask-Sitemap==0.3.0
+   $ pip install Flask-Sitemap==0.3.1
 
 Documentation
 -------------
 
-   https://flask-sitemap.readthedocs.io/en/v0.3.0
+   https://flask-sitemap.readthedocs.io/en/v0.3.1
 
 Homepage
 --------

--- a/flask_sitemap/version.py
+++ b/flask_sitemap/version.py
@@ -17,4 +17,4 @@ This file is imported by ``flask_sitemap.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
Fixes #51.
This is needed for people to get #48 without installing directly from github.

After this is landed, tag and release this commit with
```bash
git fetch origin master
git tag v0.3.1 origin/master
git push --tags
```

It looks like https://github.com/albertyw/flask-sitemap/blob/master/.github/workflows/pypi-release.yml will automatically build a new release and upload to https://pypi.org/project/Flask-Sitemap/